### PR TITLE
Better import

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ then simply:
 Basics:
 ----
 
-	from timezonefinder.timezonefinder import TimezoneFinder
-	
+	from timezonefinder import TimezoneFinder
+
 	tf = TimezoneFinder()
 
 fast algorithm:

--- a/timezonefinder/__init__.py
+++ b/timezonefinder/__init__.py
@@ -1,0 +1,3 @@
+from .timezonefinder import TimezoneFinder
+
+__all__ = ('TimezoneFinder',)


### PR DESCRIPTION
There's no need to have a submodule from which users import `TimezoneFinder`, allowing imports from the top-level `timezonefinder` is cleaner and easier to use.