### PR TITLE
setup.py doesn't use download_url, use universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.rst
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     author_email='python@michelfe.it',
     license='MIT licence',
     url='https://github.com/MrMinimal64/timezonefinder',  # use the URL to the github repo
-    download_url='https://github.com/MrMinimal64/timezonefinder/tarball/1.4.0',
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
* Upload the package to PyPI rather than leaving it on Github so it's easier to cache in downstream PyPI caches
* Use universal wheels so the package can be made into a single wheel that works on Python 2 and 3