### PR TITLE
Fix packaging - include README.rst so setup.py works

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md
+include README.rst
 include LICENSE
 
 recursive-include test *


### PR DESCRIPTION
You can test your setup.py is working with `tox`, which does a full `setup.py install` in the test virtualenvs