### PR TITLE
setup.cfg - fix [wheel] -> [bdist_wheel]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
+[bdist_wheel]
+universal = 1
+
 [metadata]
 description-file = README.rst
-
-[wheel]
-universal = 1


### PR DESCRIPTION
[wheel] is legacy, [bdist_wheel] is the future. See  https://bitbucket.org/pypa/wheel/src/4da780b849affbff98a0defb21ad1f30a94d6f57/wheel/bdist_wheel.py?at=default&fileviewer=file-view-default#bdist_wheel.py-119