### PR TITLE
tox - pass posargs to py.test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,5 @@ envlist = py{34,35}
 [testenv]
 install_command = pip install --no-deps {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
-commands = py.test
+commands = py.test {posargs}
 setenv = LC_ALL = en_US.utf-8


### PR DESCRIPTION
This allows running e.g. `tox -- -v` for verbose py.test.