### PR TITLE
Test tidy up

### DIFF
--- a/test/test_it.py
+++ b/test/test_it.py
@@ -4,432 +4,6 @@ import random
 from datetime import datetime
 from tzwhere.tzwhere import tzwhere
 
-time_zones = {
-    "Europe/Andorra": 1,
-    "Asia/Dubai": 2,
-    "Asia/Kabul": 3,
-    "America/Antigua": 4,
-    "America/Anguilla": 5,
-    "Europe/Tirane": 6,
-    "Asia/Yerevan": 7,
-    "Africa/Luanda": 8,
-    "Antarctica/McMurdo": 9,
-    "Antarctica/Rothera": 10,
-    "Antarctica/Palmer": 11,
-    "Antarctica/Mawson": 12,
-    "Antarctica/Davis": 13,
-    "Antarctica/Casey": 14,
-    "Antarctica/Vostok": 15,
-    "Antarctica/DumontDUrville": 16,
-    "Antarctica/Syowa": 17,
-    "Antarctica/Troll": 18,
-    "America/Argentina/Buenos_Aires": 19,
-    "America/Argentina/Cordoba": 20,
-    "America/Argentina/Salta": 21,
-    "America/Argentina/Jujuy": 22,
-    "America/Argentina/Tucuman": 23,
-    "America/Argentina/Catamarca": 24,
-    "America/Argentina/La_Rioja": 25,
-    "America/Argentina/San_Juan": 26,
-    "America/Argentina/Mendoza": 27,
-    "America/Argentina/San_Luis": 28,
-    "America/Argentina/Rio_Gallegos": 29,
-    "America/Argentina/Ushuaia": 30,
-    "Pacific/Pago_Pago": 31,
-    "Europe/Vienna": 32,
-    "Australia/Lord_Howe": 33,
-    "Antarctica/Macquarie": 34,
-    "Australia/Hobart": 35,
-    "Australia/Currie": 36,
-    "Australia/Melbourne": 37,
-    "Australia/Broken_Hill": 39,
-    "Australia/Brisbane": 40,
-    "Australia/Lindeman": 41,
-    "Australia/Adelaide": 42,
-    "Australia/Darwin": 43,
-    "Australia/Perth": 44,
-    "Australia/Eucla": 45,
-    "America/Aruba": 46,
-    "Europe/Mariehamn": 47,
-    "Asia/Baku": 48,
-    "Europe/Sarajevo": 49,
-    "America/Barbados": 50,
-    "Asia/Dhaka": 51,
-    "Europe/Brussels": 52,
-    "Africa/Ouagadougou": 53,
-    "Europe/Sofia": 54,
-    "Asia/Bahrain": 55,
-    "Africa/Bujumbura": 56,
-    "Africa/Porto-Novo": 57,
-    "America/St_Barthelemy": 58,
-    "Atlantic/Bermuda": 59,
-    "Asia/Brunei": 60,
-    "America/La_Paz": 61,
-    "America/Kralendijk": 62,
-    "America/Noronha": 63,
-    "America/Belem": 64,
-    "America/Fortaleza": 65,
-    "America/Recife": 66,
-    "America/Araguaina": 67,
-    "America/Maceio": 68,
-    "America/Bahia": 69,
-    "America/Sao_Paulo": 70,
-    "America/Campo_Grande": 71,
-    "America/Cuiaba": 72,
-    "America/Santarem": 73,
-    "America/Porto_Velho": 74,
-    "America/Boa_Vista": 75,
-    "America/Manaus": 76,
-    "America/Eirunepe": 77,
-    "America/Rio_Branco": 78,
-    "America/Nassau": 79,
-    "Asia/Thimphu": 80,
-    "Africa/Gaborone": 81,
-    "Europe/Minsk": 82,
-    "America/Belize": 83,
-    "America/St_Johns": 84,
-    "America/Halifax": 85,
-    "America/Glace_Bay": 86,
-    "America/Moncton": 87,
-    "America/Goose_Bay": 88,
-    "America/Blanc-Sablon": 89,
-    "America/Toronto": 90,
-    "America/Nipigon": 91,
-    "America/Thunder_Bay": 92,
-    "America/Iqaluit": 93,
-    "America/Pangnirtung": 94,
-    "America/Resolute": 95,
-    "America/Atikokan": 96,
-    "America/Rankin_Inlet": 97,
-    "America/Winnipeg": 98,
-    "America/Rainy_River": 99,
-    "America/Regina": 100,
-    "America/Swift_Current": 101,
-    "America/Edmonton": 102,
-    "America/Cambridge_Bay": 103,
-    "America/Yellowknife": 104,
-    "America/Inuvik": 105,
-    "America/Creston": 106,
-    "America/Dawson_Creek": 107,
-    "America/Fort_Nelson": 108,
-    "America/Vancouver": 109,
-    "America/Whitehorse": 110,
-    "America/Dawson": 111,
-    "Indian/Cocos": 112,
-    "Africa/Kinshasa": 113,
-    "Africa/Lubumbashi": 114,
-    "Africa/Bangui": 115,
-    "Africa/Brazzaville": 116,
-    "Europe/Zurich": 117,
-    "Africa/Abidjan": 118,
-    "Pacific/Rarotonga": 119,
-    "America/Santiago": 120,
-    "Pacific/Easter": 121,
-    "Africa/Douala": 122,
-    "Asia/Shanghai": 123,
-    "Asia/Urumqi": 124,
-    "America/Bogota": 125,
-    "America/Costa_Rica": 126,
-    "America/Havana": 127,
-    "Atlantic/Cape_Verde": 128,
-    "America/Curacao": 129,
-    "Indian/Christmas": 130,
-    "Asia/Nicosia": 131,
-    "Europe/Prague": 132,
-    "Europe/Berlin": 133,
-    "Europe/Busingen": 134,
-    "Africa/Djibouti": 135,
-    "Europe/Copenhagen": 136,
-    "America/Dominica": 137,
-    "America/Santo_Domingo": 138,
-    "Africa/Algiers": 139,
-    "America/Guayaquil": 140,
-    "Pacific/Galapagos": 141,
-    "Europe/Tallinn": 142,
-    "Africa/Cairo": 143,
-    "Africa/El_Aaiun": 144,
-    "Africa/Asmara": 145,
-    "Europe/Madrid": 146,
-    "Africa/Ceuta": 147,
-    "Atlantic/Canary": 148,
-    "Africa/Addis_Ababa": 149,
-    "Europe/Helsinki": 150,
-    "Pacific/Fiji": 151,
-    "Atlantic/Stanley": 152,
-    "Pacific/Chuuk": 153,
-    "Pacific/Pohnpei": 154,
-    "Pacific/Kosrae": 155,
-    "Atlantic/Faroe": 156,
-    "Europe/Paris": 157,
-    "Africa/Libreville": 158,
-    "Europe/London": 159,
-    "America/Grenada": 160,
-    "Asia/Tbilisi": 161,
-    "America/Cayenne": 162,
-    "Europe/Guernsey": 163,
-    "Africa/Accra": 164,
-    "Europe/Gibraltar": 165,
-    "America/Godthab": 166,
-    "America/Danmarkshavn": 167,
-    "America/Scoresbysund": 168,
-    "America/Thule": 169,
-    "Africa/Banjul": 170,
-    "Africa/Conakry": 171,
-    "America/Guadeloupe": 172,
-    "Africa/Malabo": 173,
-    "Europe/Athens": 174,
-    "Atlantic/South_Georgia": 175,
-    "America/Guatemala": 176,
-    "Pacific/Guam": 177,
-    "Africa/Bissau": 178,
-    "America/Guyana": 179,
-    "Asia/Hong_Kong": 180,
-    "America/Tegucigalpa": 181,
-    "Europe/Zagreb": 182,
-    "America/Port-au-Prince": 183,
-    "Europe/Budapest": 184,
-    "Asia/Jakarta": 185,
-    "Asia/Pontianak": 186,
-    "Asia/Makassar": 187,
-    "Asia/Jayapura": 188,
-    "Europe/Dublin": 189,
-    "Asia/Jerusalem": 190,
-    "Europe/Isle_of_Man": 191,
-    "Asia/Kolkata": 192,
-    "Indian/Chagos": 193,
-    "Asia/Baghdad": 194,
-    "Asia/Tehran": 195,
-    "Atlantic/Reykjavik": 196,
-    "Europe/Rome": 197,
-    "Europe/Jersey": 198,
-    "America/Jamaica": 199,
-    "Asia/Amman": 200,
-    "Asia/Tokyo": 201,
-    "Africa/Nairobi": 202,
-    "Asia/Bishkek": 203,
-    "Asia/Phnom_Penh": 204,
-    "Pacific/Tarawa": 205,
-    "Pacific/Enderbury": 206,
-    "Pacific/Kiritimati": 207,
-    "Indian/Comoro": 208,
-    "America/St_Kitts": 209,
-    "Asia/Pyongyang": 210,
-    "Asia/Seoul": 211,
-    "Asia/Kuwait": 212,
-    "America/Cayman": 213,
-    "Asia/Almaty": 214,
-    "Asia/Qyzylorda": 215,
-    "Asia/Aqtobe": 216,
-    "Asia/Aqtau": 217,
-    "Asia/Oral": 218,
-    "Asia/Vientiane": 219,
-    "Asia/Beirut": 220,
-    "America/St_Lucia": 221,
-    "Europe/Vaduz": 222,
-    "Asia/Colombo": 223,
-    "Africa/Monrovia": 224,
-    "Africa/Maseru": 225,
-    "Europe/Vilnius": 226,
-    "Europe/Luxembourg": 227,
-    "Europe/Riga": 228,
-    "Africa/Tripoli": 229,
-    "Africa/Casablanca": 230,
-    "Europe/Monaco": 231,
-    "Europe/Chisinau": 232,
-    "Europe/Podgorica": 233,
-    "America/Marigot": 234,
-    "Indian/Antananarivo": 235,
-    "Pacific/Majuro": 236,
-    "Pacific/Kwajalein": 237,
-    "Europe/Skopje": 238,
-    "Africa/Bamako": 239,
-    "Asia/Rangoon": 240,
-    "Asia/Ulaanbaatar": 241,
-    "Asia/Hovd": 242,
-    "Asia/Choibalsan": 243,
-    "Asia/Macau": 244,
-    "Pacific/Saipan": 245,
-    "America/Martinique": 246,
-    "Africa/Nouakchott": 247,
-    "America/Montserrat": 248,
-    "Europe/Malta": 249,
-    "Indian/Mauritius": 250,
-    "Indian/Maldives": 251,
-    "Africa/Blantyre": 252,
-    "America/Mexico_City": 253,
-    "America/Cancun": 254,
-    "America/Merida": 255,
-    "America/Monterrey": 256,
-    "America/Matamoros": 257,
-    "America/Mazatlan": 258,
-    "America/Chihuahua": 259,
-    "America/Ojinaga": 260,
-    "America/Hermosillo": 261,
-    "America/Tijuana": 262,
-    "America/Santa_Isabel": 263,
-    "America/Bahia_Banderas": 264,
-    "Asia/Kuala_Lumpur": 265,
-    "Asia/Kuching": 266,
-    "Africa/Maputo": 267,
-    "Africa/Windhoek": 268,
-    "Pacific/Noumea": 269,
-    "Africa/Niamey": 270,
-    "Pacific/Norfolk": 271,
-    "Africa/Lagos": 272,
-    "America/Managua": 273,
-    "Europe/Amsterdam": 274,
-    "Europe/Oslo": 275,
-    "Asia/Kathmandu": 276,
-    "Pacific/Nauru": 277,
-    "Pacific/Niue": 278,
-    "Pacific/Auckland": 279,
-    "Pacific/Chatham": 280,
-    "Asia/Muscat": 281,
-    "America/Panama": 282,
-    "America/Lima": 283,
-    "Pacific/Tahiti": 284,
-    "Pacific/Marquesas": 285,
-    "Pacific/Gambier": 286,
-    "Pacific/Port_Moresby": 287,
-    "Pacific/Bougainville": 288,
-    "Asia/Manila": 289,
-    "Asia/Karachi": 290,
-    "Europe/Warsaw": 291,
-    "America/Miquelon": 292,
-    "Pacific/Pitcairn": 293,
-    "America/Puerto_Rico": 294,
-    "Asia/Gaza": 295,
-    "Asia/Hebron": 296,
-    "Europe/Lisbon": 297,
-    "Atlantic/Madeira": 298,
-    "Atlantic/Azores": 299,
-    "Pacific/Palau": 300,
-    "America/Asuncion": 301,
-    "Asia/Qatar": 302,
-    "Indian/Reunion": 303,
-    "Europe/Bucharest": 304,
-    "Europe/Belgrade": 305,
-    "Europe/Kaliningrad": 306,
-    "Europe/Moscow": 307,
-    "Europe/Simferopol": 308,
-    "Europe/Volgograd": 309,
-    "Europe/Samara": 310,
-    "Asia/Yekaterinburg": 311,
-    "Asia/Omsk": 312,
-    "Asia/Novosibirsk": 313,
-    "Asia/Novokuznetsk": 314,
-    "Asia/Krasnoyarsk": 315,
-    "Asia/Irkutsk": 316,
-    "Asia/Chita": 317,
-    "Asia/Yakutsk": 318,
-    "Asia/Khandyga": 319,
-    "Asia/Vladivostok": 320,
-    "Asia/Sakhalin": 321,
-    "Asia/Ust-Nera": 322,
-    "Asia/Magadan": 323,
-    "Asia/Srednekolymsk": 324,
-    "Asia/Kamchatka": 325,
-    "Asia/Anadyr": 326,
-    "Africa/Kigali": 327,
-    "Asia/Riyadh": 328,
-    "Pacific/Guadalcanal": 329,
-    "Indian/Mahe": 330,
-    "Africa/Khartoum": 331,
-    "Europe/Stockholm": 332,
-    "Asia/Singapore": 333,
-    "Atlantic/St_Helena": 334,
-    "Europe/Ljubljana": 335,
-    "Arctic/Longyearbyen": 336,
-    "Europe/Bratislava": 337,
-    "Africa/Freetown": 338,
-    "Europe/San_Marino": 339,
-    "Africa/Dakar": 340,
-    "Africa/Mogadishu": 341,
-    "America/Paramaribo": 342,
-    "Africa/Juba": 343,
-    "Africa/Sao_Tome": 344,
-    "America/El_Salvador": 345,
-    "America/Lower_Princes": 346,
-    "Asia/Damascus": 347,
-    "Africa/Mbabane": 348,
-    "America/Grand_Turk": 349,
-    "Africa/Ndjamena": 350,
-    "Indian/Kerguelen": 351,
-    "Africa/Lome": 352,
-    "Asia/Bangkok": 353,
-    "Asia/Dushanbe": 354,
-    "Pacific/Fakaofo": 355,
-    "Asia/Dili": 356,
-    "Asia/Ashgabat": 357,
-    "Africa/Tunis": 358,
-    "Pacific/Tongatapu": 359,
-    "Europe/Istanbul": 360,
-    "America/Port_of_Spain": 361,
-    "Pacific/Funafuti": 362,
-    "Asia/Taipei": 363,
-    "Africa/Dar_es_Salaam": 364,
-    "Europe/Kiev": 365,
-    "Europe/Uzhgorod": 366,
-    "Europe/Zaporozhye": 367,
-    "Africa/Kampala": 368,
-    "Pacific/Johnston": 369,
-    "Pacific/Midway": 370,
-    "Pacific/Wake": 371,
-    "America/New_York": 372,
-    "America/Detroit": 373,
-    "America/Kentucky/Louisville": 374,
-    "America/Kentucky/Monticello": 375,
-    "America/Indiana/Indianapolis": 376,
-    "America/Indiana/Vincennes": 377,
-    "America/Indiana/Winamac": 378,
-    "America/Indiana/Marengo": 379,
-    "America/Indiana/Petersburg": 380,
-    "America/Indiana/Vevay": 381,
-    "America/Chicago": 382,
-    "America/Indiana/Tell_City": 383,
-    "America/Indiana/Knox": 384,
-    "America/Menominee": 385,
-    "America/North_Dakota/Center": 386,
-    "America/North_Dakota/New_Salem": 387,
-    "America/North_Dakota/Beulah": 388,
-    "America/Denver": 389,
-    "America/Boise": 390,
-    "America/Phoenix": 391,
-    "America/Los_Angeles": 392,
-    "America/Metlakatla": 393,
-    "America/Anchorage": 394,
-    "America/Juneau": 395,
-    "America/Sitka": 396,
-    "America/Yakutat": 397,
-    "America/Nome": 398,
-    "America/Adak": 399,
-    "Pacific/Honolulu": 400,
-    "America/Montevideo": 401,
-    "Asia/Samarkand": 402,
-    "Asia/Tashkent": 403,
-    "Europe/Vatican": 404,
-    "America/St_Vincent": 405,
-    "America/Caracas": 406,
-    "America/Tortola": 407,
-    "America/St_Thomas": 408,
-    "Asia/Ho_Chi_Minh": 409,
-    "Pacific/Efate": 410,
-    "Pacific/Wallis": 411,
-    "Pacific/Apia": 412,
-    "Asia/Aden": 413,
-    "Indian/Mayotte": 414,
-    "Africa/Johannesburg": 415,
-    "Africa/Lusaka": 416,
-    "Africa/Harare": 417,
-    'Asia/Kashgar': 418,
-    'America/Montreal': 419,
-    'Asia/Harbin': 420,
-    'America/Coral_Harbour': 421,
-    'uninhabited': 422,
-    'Australia/Sydney': 423,
-    'Asia/Chongqing': 424
-}
-
 
 def random_point():
     # tzwhere does not work for points with more latitude!
@@ -509,13 +83,6 @@ class PackageEqualityTest(unittest.TestCase):
         (33, -84): 'uninhabited',
 
     }
-
-    def setUp(self):
-        # preparations for every test case
-        pass
-
-    def tearDown(self):
-        pass
 
     def test_correctness(self):
         # Test correctness
@@ -633,7 +200,7 @@ class PackageEqualityTest(unittest.TestCase):
 
     def test_startup_time(self):
 
-        def test_speed_his_algor():
+        def check_speed_his_algor():
             start_time = datetime.now()
 
             tz_where = tzwhere()
@@ -644,7 +211,7 @@ class PackageEqualityTest(unittest.TestCase):
 
             return end_time - start_time
 
-        def test_speed_my_algor():
+        def check_speed_my_algor():
             start_time = datetime.now()
 
             timezonefinder = TimezoneFinder()
@@ -655,8 +222,8 @@ class PackageEqualityTest(unittest.TestCase):
 
             return end_time - start_time
 
-        my_time = test_speed_my_algor()
-        his_time = test_speed_his_algor()
+        my_time = check_speed_my_algor()
+        his_time = check_speed_his_algor()
 
         print('\nStartup times:')
         print('tzwhere:', his_time)
@@ -667,7 +234,7 @@ class PackageEqualityTest(unittest.TestCase):
 
     def test_speed(self):
 
-        def test_speed_his_algor(points):
+        def check_speed_his_algor(points):
             start_time = datetime.now()
 
             # old algorithm (tzwhere)
@@ -683,7 +250,7 @@ class PackageEqualityTest(unittest.TestCase):
 
             # test second algorithm ( double, .bin)
 
-        def test_speed_my_algor(points):
+        def check_speed_my_algor(points):
             # test final algorithm ( long long, .bin)
 
             start_time = datetime.now()
@@ -697,11 +264,11 @@ class PackageEqualityTest(unittest.TestCase):
 
         runs = 1
 
-        my_time = test_speed_my_algor(self.realistic_points)
-        his_time = test_speed_his_algor(self.realistic_points)
+        my_time = check_speed_my_algor(self.realistic_points)
+        his_time = check_speed_his_algor(self.realistic_points)
         for i in range(runs - 1):
-            my_time += test_speed_my_algor(self.realistic_points)
-            his_time += test_speed_his_algor(self.realistic_points)
+            my_time += check_speed_my_algor(self.realistic_points)
+            his_time += check_speed_his_algor(self.realistic_points)
 
         my_time /= runs
         his_time /= runs
@@ -717,7 +284,7 @@ class PackageEqualityTest(unittest.TestCase):
 
     def test_speed_random(self):
 
-        def test_speed_his_algor(points):
+        def check_speed_his_algor(points):
             start_time = datetime.now()
 
             # old algorithm (tzwhere)
@@ -733,7 +300,7 @@ class PackageEqualityTest(unittest.TestCase):
 
             # test second algorithm ( double, .bin)
 
-        def test_speed_my_algor(points):
+        def check_speed_my_algor(points):
             # test final algorithm ( long long, .bin)
 
             start_time = datetime.now()
@@ -750,11 +317,11 @@ class PackageEqualityTest(unittest.TestCase):
         for i in range(self.n):
             random_points.append(random_point())
 
-        my_time = test_speed_my_algor(random_points)
-        his_time = test_speed_his_algor(random_points)
+        my_time = check_speed_my_algor(random_points)
+        his_time = check_speed_his_algor(random_points)
         for i in range(self.runs - 1):
-            my_time += test_speed_my_algor(random_points)
-            his_time += test_speed_his_algor(random_points)
+            my_time += check_speed_my_algor(random_points)
+            his_time += check_speed_his_algor(random_points)
 
         my_time /= self.runs
         his_time /= self.runs


### PR DESCRIPTION
* No empty `setUp` / `tearDown` functions
* Rename the inner 'test_' functions to 'check_' - a reader might mistake them for wrongly indented test case functions (I did at first glance when trying to understand them).
* Remove `time_zones` which adds 426 unnecessary lines to the file (it's already in `file_converter`, maybe it should be moved to a single place in the main module if it does need sharing?).