### PR TITLE
Tests - add runtests.py that runs linter programs and py.test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
+docutils==0.12
+flake8==2.5.4
+isort==4.2.5
 numpy==1.11.0
+pep8==1.7.0
 py==1.4.31
+pyflakes==1.1.0
+Pygments==2.1.3
 pytest==2.9.1
 tzwhere==2.2

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import subprocess
+import sys
+from lib2to3.main import main as lib2to3_main
+
+import pytest
+from flake8.main import main as flake8_main
+
+
+CODE_PATHS = [
+    'runtests.py',
+    'timezonefinder',
+    'test',
+]
+
+
+def main():
+    try:
+        sys.argv.remove('--nolint')
+    except ValueError:
+        run_lint = True
+    else:
+        run_lint = False
+
+    try:
+        sys.argv.remove('--lintonly')
+    except ValueError:
+        run_tests = True
+    else:
+        run_tests = False
+
+    if run_tests:
+        exit_on_failure(tests_main())
+
+    if run_lint:
+        exit_on_failure(run_flake8())
+        exit_on_failure(run_2to3())
+        exit_on_failure(run_isort())
+
+        # Broken on 2.7.9 due to http://bugs.python.org/issue23063
+        if sys.version_info[:3] != (2, 7, 9):
+            exit_on_failure(run_setup_py_check())
+
+
+def tests_main():
+    return pytest.main()
+
+
+def run_flake8():
+    print('Running flake8 code linting')
+    try:
+        original_argv = sys.argv
+        sys.argv = ['flake8'] + CODE_PATHS
+        did_fail = False
+        flake8_main()
+    except SystemExit:
+        did_fail = True
+    finally:
+        sys.argv = original_argv
+
+    print('flake8 failed' if did_fail else 'flake8 passed')
+    return did_fail
+
+
+def run_2to3():
+    print('Running 2to3 checks')
+    ret = lib2to3_main('lib2to3.fixes', [
+        '-f', 'idioms',
+        '-f', 'isinstance',
+        '-f', 'set_literal',
+        '-f', 'tuple_params',
+        '-j', '4',
+    ] + CODE_PATHS)
+    print('2to3 failed' if ret else '2to3 passed')
+    return ret
+
+
+def run_isort():
+    print('Running isort check')
+    return subprocess.call([
+        'isort', '--recursive', '--check-only', '--diff',
+        '-a', 'from __future__ import absolute_import, division',
+        '-a', 'from __future__ import print_function, unicode_literals',
+    ] + CODE_PATHS)
+
+
+def run_setup_py_check():
+    print('Running setup.py check')
+    return subprocess.call([
+        'python', 'setup.py', 'check',
+        '-s', '--restructuredtext', '--metadata'
+    ])
+
+
+def exit_on_failure(ret, message=None):
+    if ret:
+        sys.exit(ret)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,12 @@
 universal = 1
 python-tag = py34.py35
 
+[flake8]
+max-line-length = 120
+
+[isort]
+not_skip = __init__.py
+
 [metadata]
 description-file = README.rst
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
+# -*- coding:utf-8 -*-
+
 import os
 import re
 
-#from distutils.core import setup
 from setuptools import setup
-import sys
 
 
 def get_version(package):

--- a/test/test_it.py
+++ b/test/test_it.py
@@ -1,7 +1,10 @@
-import unittest
-from timezonefinder.timezonefinder import TimezoneFinder
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import random
+import unittest
 from datetime import datetime
+
+from timezonefinder.timezonefinder import TimezoneFinder
 from tzwhere.tzwhere import tzwhere
 
 
@@ -19,7 +22,6 @@ class PackageEqualityTest(unittest.TestCase):
         print('Numba is NOT being used.')
 
     timezone_finder = TimezoneFinder()
-
 
     tz_where = tzwhere()
 
@@ -84,7 +86,6 @@ class PackageEqualityTest(unittest.TestCase):
 
     }
 
-
     def test_correctness(self):
         # Test correctness
         print('\ntest correctness:')
@@ -103,7 +104,7 @@ class PackageEqualityTest(unittest.TestCase):
         # Test the equality if the two algorithms
 
         mistakes = 0
-        print('\ntesting', self.n,'realistic points')
+        print('\ntesting', self.n, 'realistic points')
         print('MISMATCHES:')
 
         i = 0
@@ -140,7 +141,6 @@ class PackageEqualityTest(unittest.TestCase):
                     # print('mistake at point:', p)
                     # print(my_result, 'should be equal to', his_result)
                     # raise AssertionError('There was a mistake')
-
 
                     # assert my_result == his_result
 
@@ -235,8 +235,6 @@ class PackageEqualityTest(unittest.TestCase):
 
         assert his_time > my_time
 
-
-
     def test_speed(self):
 
         def check_speed_his_algor(points):
@@ -251,7 +249,6 @@ class PackageEqualityTest(unittest.TestCase):
             return end_time - start_time
 
             # test my first algorithm (boundaries, csv)
-
 
             # test second algorithm ( double, .bin)
 
@@ -274,7 +271,6 @@ class PackageEqualityTest(unittest.TestCase):
         for i in range(runs - 1):
             my_time += check_speed_my_algor(self.realistic_points)
             his_time += check_speed_his_algor(self.realistic_points)
-
 
         my_time /= self.runs
         his_time /= self.runs
@@ -305,7 +301,6 @@ class PackageEqualityTest(unittest.TestCase):
             return end_time - start_time
 
             # test my first algorithm (boundaries, csv)
-
 
             # test second algorithm ( double, .bin)
 
@@ -346,4 +341,3 @@ class PackageEqualityTest(unittest.TestCase):
             pass
 
         assert his_time > my_time
-

--- a/timezonefinder/__init__.py
+++ b/timezonefinder/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from .timezonefinder import TimezoneFinder
 
 __version__ = '1.5.1'

--- a/timezonefinder/file_converter.py
+++ b/timezonefinder/file_converter.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import linecache
 import math
 import re
 from datetime import datetime
-from struct import *
+from struct import pack
 
 # number of shortcuts per longitude
 NR_SHORTCUTS_PER_LNG = 1
@@ -719,9 +721,8 @@ def compile_into_binary(path='tz_binary.bin'):
             # print(y_longs)
             # print(x_intersections(coordinate_to_longlong(lat), x_longs, y_longs))
             # raise ValueError
-            intersects = [longlong_to_coordinate(x) for x in
-                          x_intersections(coordinate_to_longlong(lat), x_longs, y_longs)]
-            intersects.sort()
+            intersects = sorted([longlong_to_coordinate(x) for x in
+                                 x_intersections(coordinate_to_longlong(lat), x_longs, y_longs)])
             # print(intersects)
 
             nr_of_intersects = len(intersects)
@@ -782,9 +783,8 @@ def compile_into_binary(path='tz_binary.bin'):
             # print(coordinate_to_longlong(lng))
             # print(x_longs)
             # print(x_intersections(coordinate_to_longlong(lng), x_longs, y_longs))
-            intersects = [longlong_to_coordinate(y) for y in
-                          y_intersections(coordinate_to_longlong(lng), x_longs, y_longs)]
-            intersects.sort()
+            intersects = sorted([longlong_to_coordinate(y) for y in
+                                 y_intersections(coordinate_to_longlong(lng), x_longs, y_longs)])
             # print(intersects)
 
             nr_of_intersects = len(intersects)
@@ -856,9 +856,9 @@ def compile_into_binary(path='tz_binary.bin'):
                 print('This is a big zone! computing exact shortcuts')
                 print('Nr of entries before')
                 print(len(column_nrs) * len(row_nrs))
-                
+
                 print('columns and rows before optimisation:')
-                
+
                 print(column_nrs)
                 print(row_nrs)
                 '''
@@ -894,7 +894,7 @@ def compile_into_binary(path='tz_binary.bin'):
                 '''
                 print('and after:')
                 print(len(shortcuts_for_line))
-                
+
                 column_nrs_after = set()
                 row_nrs_after = set()
                 for x, y in shortcuts_for_line:

--- a/timezonefinder/helpers.py
+++ b/timezonefinder/helpers.py
@@ -1,4 +1,6 @@
-from math import radians, cos, sin, asin, sqrt, degrees, ceil, atan2
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from math import asin, atan2, ceil, cos, degrees, radians, sin, sqrt
 
 
 def position_to_line(x, y, x1, x2, y1, y2):
@@ -116,13 +118,13 @@ def inside_polygon(x, y, coords):
             if y2 >= y:
                 x1 = coords[0][i - 1]
                 x2 = coords[0][i]
-                # print(long2coord(x), long2coord(y), long2coord(x1), long2coord(x2), long2coord(y1), long2coord(y2),position_to_line(x, y, x1, x2, y1, y2))
+                # print(long2coord(x), long2coord(y), long2coord(x1), long2coord(x2), long2coord(y1), long2coord(y2),
+                #       position_to_line(x, y, x1, x2, y1, y2))
                 if position_to_line(x, y, x1, x2, y1, y2) == 2:
                     # point is left of line
                     # return true when its on the line?! this is very unlikely to happen!
                     # and would need to be checked every time!
                     wn += 1
-
 
         else:
             if y2 < y:

--- a/timezonefinder/helpers_numba.py
+++ b/timezonefinder/helpers_numba.py
@@ -1,4 +1,7 @@
-from math import radians, cos, sin, asin, sqrt, degrees, ceil, atan2
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from math import asin, atan2, ceil, cos, degrees, radians, sin, sqrt
+
 from numba import jit
 
 
@@ -119,13 +122,13 @@ def inside_polygon(x, y, coords):
             if y2 >= y:
                 x1 = coords[0][i - 1]
                 x2 = coords[0][i]
-                # print(long2coord(x), long2coord(y), long2coord(x1), long2coord(x2), long2coord(y1), long2coord(y2),position_to_line(x, y, x1, x2, y1, y2))
+                # print(long2coord(x), long2coord(y), long2coord(x1), long2coord(x2), long2coord(y1), long2coord(y2),
+                #       position_to_line(x, y, x1, x2, y1, y2))
                 if position_to_line(x, y, x1, x2, y1, y2) == 2:
                     # point is left of line
                     # return true when its on the line?! this is very unlikely to happen!
                     # and would need to be checked every time!
                     wn += 1
-
 
         else:
             if y2 < y:

--- a/timezonefinder/timezonefinder.py
+++ b/timezonefinder/timezonefinder.py
@@ -1,7 +1,10 @@
-from math import radians, cos, sin, asin, sqrt, floor, degrees, ceil, atan2
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from math import floor
+from os.path import dirname, join
 from struct import unpack
-from numpy import fromfile, empty, array
-from os.path import join, dirname
+
+from numpy import array, empty, fromfile
 
 try:
     import numba
@@ -9,9 +12,9 @@ except ImportError:
     numba = None
 
 if numba is not None:
-    from .helpers_numba import *
+    from .helpers_numba import coord2long, distance_to_polygon, inside_polygon
 else:
-    from .helpers import *
+    from .helpers import coord2long, distance_to_polygon, inside_polygon
 
 
 # maps the timezone ids to their name

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,14 @@
 [tox]
-envlist = py{27,34,35}
+envlist = py{27,34,35},py{27,35}-codestyle
 
 [testenv]
 install_command = pip install --no-deps {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
-commands = py.test {posargs}
+commands = ./runtests.py --nolint {posargs}
 setenv = LC_ALL = en_US.utf-8
+
+[testenv:py27-codestyle]
+commands = ./runtests.py --lintonly
+
+[testenv:py35-codestyle]
+commands = ./runtests.py --lintonly


### PR DESCRIPTION
This is a script adapted from my other projects. It runs several useful linter programs to keep source consistent and detect errors:

* `flake8` - keeps code in line with PEP8 plus detects potential errors with pyflakes
* `2to3` - a built-in Python tool that can help detect forwards-compatibility fixes for Python 2. Not all are activated since some subtly change the semantics.
* `isort` - keeps imports in order, and is configured to add the `__future__` imports for forwards compatibility in Python 2.7
* `setup.py check` - checks your `setup.py` is correctly configured and that your `long_description` (README.rst) will render correctly on PyPI