### PR TITLE
Support Python 2.7.6

### DIFF
--- a/timezonefinder/file_converter.py
+++ b/timezonefinder/file_converter.py
@@ -947,19 +947,19 @@ def compile_into_binary(path='tz_binary.bin'):
     print('now writing file "', path, '"')
     output_file = open(path, 'wb')
     # write nr_of_lines
-    output_file.write(pack('!H', nr_of_lines))
+    output_file.write(pack(b'!H', nr_of_lines))
     # write start address of shortcut_data:
-    output_file.write(pack('!I', shortcut_start_address))
+    output_file.write(pack(b'!I', shortcut_start_address))
     # write zone_ids
     for zone_id in zone_ids:
-        output_file.write(pack('!H', zone_id))
+        output_file.write(pack(b'!H', zone_id))
     # write number of values
     for length in _length_of_rows():
-        output_file.write(pack('!H', length))
+        output_file.write(pack(b'!H', length))
 
     # write polygon_addresses
     for length in _length_of_rows():
-        output_file.write(pack('!I', polygon_address))
+        output_file.write(pack(b'!I', polygon_address))
         polygon_address += 16 * length
 
     if shortcut_start_address != polygon_address:
@@ -968,16 +968,16 @@ def compile_into_binary(path='tz_binary.bin'):
 
     # write boundary_data
     for xmax, xmin, ymax, ymin in _boundaries():
-        output_file.write(pack('!qqqq',
+        output_file.write(pack(b'!qqqq',
                                coordinate_to_longlong(xmax), coordinate_to_longlong(xmin), coordinate_to_longlong(ymax),
                                coordinate_to_longlong(ymin)))
 
     # write polygon_data
     for x_coords, y_coords in _coordinates():
         for x in x_coords:
-            output_file.write(pack('!q', coordinate_to_longlong(x)))
+            output_file.write(pack(b'!q', coordinate_to_longlong(x)))
         for y in y_coords:
-            output_file.write(pack('!q', coordinate_to_longlong(y)))
+            output_file.write(pack(b'!q', coordinate_to_longlong(y)))
 
     print('position after writing all polygon data:', output_file.tell())
     # write number of entries in shortcut field (x,y)
@@ -1007,16 +1007,16 @@ def compile_into_binary(path='tz_binary.bin'):
     for nr in nr_of_entries_in_shortcut:
         if nr > 300:
             raise ValueError(nr)
-        output_file.write(pack('!H', nr))
+        output_file.write(pack(b'!H', nr))
 
     # write  Address of first Polygon_nr  in shortcut field (x,y)
     # Attention: 0 is written when no entries are in this shortcut
     shortcut_address = output_file.tell() + 259200 * NR_SHORTCUTS_PER_LNG * NR_SHORTCUTS_PER_LAT
     for nr in nr_of_entries_in_shortcut:
         if nr == 0:
-            output_file.write(pack('!I', 0))
+            output_file.write(pack(b'!I', 0))
         else:
-            output_file.write(pack('!I', shortcut_address))
+            output_file.write(pack(b'!I', shortcut_address))
             # each polygon takes up 2 bytes of space
             shortcut_address += 2 * nr
 
@@ -1025,7 +1025,7 @@ def compile_into_binary(path='tz_binary.bin'):
         for entry in entries:
             if entry > nr_of_lines:
                 raise ValueError(entry)
-            output_file.write(pack('!H', entry))
+            output_file.write(pack(b'!H', entry))
 
     print('Success!')
     return

--- a/timezonefinder/timezonefinder.py
+++ b/timezonefinder/timezonefinder.py
@@ -458,11 +458,11 @@ class TimezoneFinder:
         # open the file in binary reading mode
         self.binary_file = open(join(dirname(__file__), 'timezone_data.bin'), 'rb')
         # read the first 2byte int (= number of polygons stored in the .bin)
-        self.nr_of_entries = unpack('!H', self.binary_file.read(2))[0]
+        self.nr_of_entries = unpack(b'!H', self.binary_file.read(2))[0]
 
         # set addresses
         # the address where the shortcut section starts (after all the polygons) this is 34 433 054
-        self.shortcuts_start = unpack('!I', self.binary_file.read(4))[0]
+        self.shortcuts_start = unpack(b'!I', self.binary_file.read(4))[0]
 
         self.nr_val_start_address = 2 * self.nr_of_entries + 6
         self.adr_start_address = 4 * self.nr_of_entries + 6
@@ -480,7 +480,7 @@ class TimezoneFinder:
     def id_of(self, line=0):
         # ids start at address 6. per line one unsigned 2byte int is used
         self.binary_file.seek((6 + 2 * line))
-        return unpack('!H', self.binary_file.read(2))[0]
+        return unpack(b'!H', self.binary_file.read(2))[0]
 
     def ids_of(self, iterable):
 
@@ -489,7 +489,7 @@ class TimezoneFinder:
         i = 0
         for line_nr in iterable:
             self.binary_file.seek((6 + 2 * line_nr))
-            id_array[i] = unpack('!H', self.binary_file.read(2))[0]
+            id_array[i] = unpack(b'!H', self.binary_file.read(2))[0]
             i += 1
 
         return id_array
@@ -504,10 +504,10 @@ class TimezoneFinder:
         # shortcuts are stored: (0,0) (0,1) (0,2)... (1,0)...
         self.binary_file.seek(self.shortcuts_start + 720 * x + 2 * y)
 
-        nr_of_polygons = unpack('!H', self.binary_file.read(2))[0]
+        nr_of_polygons = unpack(b'!H', self.binary_file.read(2))[0]
 
         self.binary_file.seek(self.first_shortcut_address + 1440 * x + 4 * y)
-        self.binary_file.seek(unpack('!I', self.binary_file.read(4))[0])
+        self.binary_file.seek(unpack(b'!I', self.binary_file.read(4))[0])
         return fromfile(self.binary_file, dtype='>u2', count=nr_of_polygons)
 
     def polygons_of_shortcut(self, x=0, y=0):
@@ -516,18 +516,18 @@ class TimezoneFinder:
         # shortcuts are stored: (0,0) (0,1) (0,2)... (1,0)...
         self.binary_file.seek(self.shortcuts_start + 720 * x + 2 * y)
 
-        nr_of_polygons = unpack('!H', self.binary_file.read(2))[0]
+        nr_of_polygons = unpack(b'!H', self.binary_file.read(2))[0]
 
         self.binary_file.seek(self.first_shortcut_address + 1440 * x + 4 * y)
-        self.binary_file.seek(unpack('!I', self.binary_file.read(4))[0])
+        self.binary_file.seek(unpack(b'!I', self.binary_file.read(4))[0])
         return fromfile(self.binary_file, dtype='>u2', count=nr_of_polygons)
 
     def coords_of(self, line=0):
         self.binary_file.seek((self.nr_val_start_address + 2 * line))
-        nr_of_values = unpack('!H', self.binary_file.read(2))[0]
+        nr_of_values = unpack(b'!H', self.binary_file.read(2))[0]
 
         self.binary_file.seek((self.adr_start_address + 4 * line))
-        self.binary_file.seek(unpack('!I', self.binary_file.read(4))[0])
+        self.binary_file.seek(unpack(b'!I', self.binary_file.read(4))[0])
 
         return array([fromfile(self.binary_file, dtype='>i8', count=nr_of_values),
                       fromfile(self.binary_file, dtype='>i8', count=nr_of_values)])


### PR DESCRIPTION
Some operating systems still package the (very old, insecure) Python 2.7.6. It's only in 2.7.8+ that unicode strings are supported by `struct.pack` / `struct.unpack`, as per this Python issue: https://bugs.python.org/issue19099

We can just always provide byte strings which work everywhere.