### PR TITLE
Make a test of distance_to_polygon more accurate

### DIFF
--- a/test/helpers_test.py
+++ b/test/helpers_test.py
@@ -160,4 +160,4 @@ class HelperTest(unittest.TestCase):
         print('=====')
         distance = distance_to_polygon(x_rad, y_rad, len(x_coords), points)
         print(km2deg(distance))
-        assert km2deg(distance) - sqrt(2) / 2 < 0.00001
+        assert abs(km2deg(distance) - sqrt(2) / 2) < 0.00001


### PR DESCRIPTION
It is invalid to succeed in the test when `distance_to_polygon()` returns lower values than expected.